### PR TITLE
Secondary header visibility issue

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -39,6 +39,10 @@
                             <span class="gh-btn gh-primary-btn">Subscribe</span>
                         </div>
                     {{/unless}}
+                {{else}}
+                    {{#if @custom.secondary_header}}
+                    <p class="gh-about-secondary">{{{@custom.secondary_header}}}</p>
+                    {{/if}}
                 {{/if}}
             </div>
         </div>


### PR DESCRIPTION
Re-enable the secondary header when the Ghost members feature is disabled, as it was inadvertently hidden by a previous commit.

Commit `bdf99841` ("Moved the secondary header inside the member check") placed the secondary header within an `{{#if @site.members_enabled}}` block. This correctly hid it for logged-in members, but it also unintentionally hid the secondary header completely when the Ghost members feature was disabled on the site, as there was no `{{else}}` condition to display it in that scenario. This PR adds the necessary `{{else}}` block to ensure the secondary header is always visible when members are disabled.

---
<a href="https://cursor.com/background-agent?bcId=bc-31d2b2d3-774d-4889-811f-f9f90dcacae7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-31d2b2d3-774d-4889-811f-f9f90dcacae7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores visibility of the secondary header when Members is turned off.
> 
> - Adds `{{else}}` branch under `{{#if @site.members_enabled}}` in `index.hbs` to render `{{@custom.secondary_header}}` when Members is disabled
> - Keeps existing behavior for logged-in and logged-out members; only affects the non-members-enabled path
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d937c38607411aa5975d1fece8a0ca627406e3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->